### PR TITLE
Rename refresh

### DIFF
--- a/frontend/components/modals/RenameModal.spec.tsx
+++ b/frontend/components/modals/RenameModal.spec.tsx
@@ -4,6 +4,7 @@ import { RenameModal } from './RenameModal';
 import { useRenameModal } from '@/store/useRenameModal';
 import { renameBoard } from '@/actions/Board';
 import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
 
 jest.mock('@/store/useRenameModal', () => ({
     useRenameModal: jest.fn(),
@@ -17,15 +18,22 @@ jest.mock('next/navigation', () => ({
     useRouter: jest.fn(),
 }));
 
+jest.mock('sonner', () => ({
+    toast: {
+        success: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
 describe('RenameModal', () => {
     const mockOnClose = jest.fn();
-    const mockRefresh = jest.fn();
+    const mockPush = jest.fn();
 
     beforeEach(() => {
         jest.clearAllMocks();
 
         (useRouter as jest.Mock).mockReturnValue({
-            refresh: mockRefresh,
+            push: mockPush,
         });
 
         (useRenameModal as unknown as jest.Mock).mockReturnValue({
@@ -73,8 +81,9 @@ describe('RenameModal', () => {
 
         await waitFor(() => {
             expect(renameBoard).toHaveBeenCalledWith('1', 'New Board Title');
-            expect(mockRefresh).toHaveBeenCalled();
+            expect(mockPush).toHaveBeenCalledWith('/');
             expect(mockOnClose).toHaveBeenCalled();
+            expect(toast.success).toHaveBeenCalledWith('Board renamed.');
         });
 
         expect(screen.queryByText(/board renamed\./i)).not.toBeInTheDocument();
@@ -94,10 +103,9 @@ describe('RenameModal', () => {
 
         await waitFor(() => {
             expect(renameBoard).toHaveBeenCalledWith('1', 'New Board Title');
+            expect(toast.error).toHaveBeenCalledWith('Failed to rename board.');
         });
 
-        expect(
-            screen.queryByText(/failed to renamed board\./i),
-        ).not.toBeInTheDocument();
+        expect(mockOnClose).not.toHaveBeenCalled();
     });
 });

--- a/frontend/components/modals/RenameModal.tsx
+++ b/frontend/components/modals/RenameModal.tsx
@@ -33,10 +33,10 @@ export const RenameModal = () => {
             e.preventDefault();
             await renameBoard(initialValues.id, title);
             toast.success('Board renamed.');
-            router.refresh();
+            router.push('/');
             onClose();
         } catch {
-            toast.error('Failed to renamed board.');
+            toast.error('Failed to rename board.');
         } finally {
             setLoading(false);
         }


### PR DESCRIPTION
## Описание изменений
- Заменён вызов router.refresh() на router.push('/') в компоненте RenameModal для перенаправления пользователя на главную страницу после успешного переименования доски.
- Обновлены тесты в RenameModal.spec.tsx для проверки вызова router.push('/') вместо router.refresh(), а также добавлены моки для функции push и обновлены проверки вызовов toast уведомлений.

## Чек-лист
- [ ] Написаны тесты
- [x] Изменения не ломают текущий функционал