### PR TITLE
Fix time board

### DIFF
--- a/backend/controllers/Board.js
+++ b/backend/controllers/Board.js
@@ -20,7 +20,8 @@ exports.getById = async (req, res) => {
 
 exports.getByOrgId = async (req, res) => {
     try {
-        const boards = await Board.find({ orgId: req.params.orgId });
+        // Сортируем по `createdAt` в порядке убывания (-1)
+        const boards = await Board.find({ orgId: req.params.orgId }).sort({ createdAt: -1 });
         return res.status(200).json(boards);
     } catch (error) {
         return res.status(500).json({ error: error.message });

--- a/backend/controllers/Board.js
+++ b/backend/controllers/Board.js
@@ -29,7 +29,16 @@ exports.getByOrgId = async (req, res) => {
 
 exports.createBoard = async (req, res) => {
     try {
-        const board = await Board.create(req.body);
+        const { title, orgId, authorId, imageUrl } = req.body;
+
+        const board = await Board.create({
+            title,
+            orgId,
+            authorId,
+            imageUrl,
+            createdAt: new Date(), // Сохраняем в UTC
+        });
+
         return res.status(200).json(board);
     } catch (error) {
         return res.status(500).json({ error: error.message });

--- a/backend/controllers/Board.js
+++ b/backend/controllers/Board.js
@@ -21,7 +21,9 @@ exports.getById = async (req, res) => {
 exports.getByOrgId = async (req, res) => {
     try {
         // Сортируем по `createdAt` в порядке убывания (-1)
-        const boards = await Board.find({ orgId: req.params.orgId }).sort({ createdAt: -1 });
+        const boards = await Board.find({ orgId: req.params.orgId }).sort({
+            createdAt: -1,
+        });
         return res.status(200).json(boards);
     } catch (error) {
         return res.status(500).json({ error: error.message });

--- a/frontend/actions/Board.tsx
+++ b/frontend/actions/Board.tsx
@@ -33,12 +33,14 @@ export async function getBoardById(
 }
 
 export async function createBoard(userId: string, orgId: string) {
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const boards = await getAllBoards(userId, orgId);
     return await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/boards`, {
         title: 'Untitle-' + boards.length,
-        orgId: orgId,
+        orgId,
         authorId: userId,
         imageUrl: `/placeholders/${Math.floor(Math.random() * 10) + 1}.svg`,
+        timezone,
     });
 }
 

--- a/frontend/app/[locale]/(dashboard)/[UserID]/_components/BoardList.tsx
+++ b/frontend/app/[locale]/(dashboard)/[UserID]/_components/BoardList.tsx
@@ -77,7 +77,7 @@ export const BoardList = ({ orgId, query }: BoardListProps) => {
                     title={board.title}
                     imageUrl={board.imageUrl}
                     authorId={board.authorId}
-                    createdAt={new Date(board.createdAt || '')}
+                    createdAt={new Date(board.createdAt || '').toISOString()}
                     orgId={board.orgId}
                 />
             ))}

--- a/frontend/app/[locale]/(dashboard)/[UserID]/_components/board-card/Footer.spec.tsx
+++ b/frontend/app/[locale]/(dashboard)/[UserID]/_components/board-card/Footer.spec.tsx
@@ -5,28 +5,27 @@ import { Footer } from './Footer';
 describe('Footer Component', () => {
     const defaultProps = {
         title: 'Sample Title',
-        authorLabel: 'John Doe',
         createdAtLabel: '2023-01-01',
         disabled: false,
     };
 
-    test('renders title, author label, and created at label', () => {
+    test('renders title correctly', () => {
         render(<Footer {...defaultProps} />);
 
-        expect(screen.getByText('Sample Title')).toBeInTheDocument();
-
-        expect(screen.getByText('John Doe, 2023-01-01')).toBeInTheDocument();
+        const titleElement = screen.getByText(defaultProps.title);
+        expect(titleElement).toBeInTheDocument();
+        expect(titleElement).toHaveClass('text-[13px]');
     });
 
-    test('button should be enabled when `disabled` prop is false', () => {
-        render(<Footer {...defaultProps} disabled={false} />);
+    test('renders createdAtLabel correctly', () => {
+        render(<Footer {...defaultProps} />);
 
-        const button = screen.getByRole('button');
-        expect(button).toBeEnabled();
-        expect(button).not.toHaveClass('cursor-not-allowed opacity-75');
+        const createdAtElement = screen.getByText(defaultProps.createdAtLabel);
+        expect(createdAtElement).toBeInTheDocument();
+        expect(createdAtElement).toHaveClass('text-[11px]');
     });
 
-    test('button should be disabled when `disabled` prop is true', () => {
+    test('button has correct styles when disabled', () => {
         render(<Footer {...defaultProps} disabled={true} />);
 
         const button = screen.getByRole('button');
@@ -34,12 +33,34 @@ describe('Footer Component', () => {
         expect(button).toHaveClass('cursor-not-allowed opacity-75');
     });
 
-    test('hover effects for author and created at labels are applied', () => {
+    test('button has correct styles when enabled', () => {
+        render(<Footer {...defaultProps} disabled={false} />);
+
+        const button = screen.getByRole('button');
+        expect(button).toBeEnabled();
+        expect(button).toHaveClass('opacity-0 group-hover:opacity-100');
+    });
+
+    test('createdAtLabel has correct hover styles', () => {
         render(<Footer {...defaultProps} />);
 
-        const authorInfo = screen.getByText('John Doe, 2023-01-01');
-        expect(authorInfo).toHaveClass(
+        const createdAtElement = screen.getByText(defaultProps.createdAtLabel);
+        expect(createdAtElement).toHaveClass(
             'opacity-0 group-hover:opacity-100 transition-opacity',
         );
+    });
+
+    test('title is truncated correctly', () => {
+        render(<Footer {...defaultProps} />);
+
+        const titleElement = screen.getByText(defaultProps.title);
+        expect(titleElement).toHaveClass('truncate max-w-[calc(100%-20px)]');
+    });
+
+    test('createdAtLabel is truncated correctly', () => {
+        render(<Footer {...defaultProps} />);
+
+        const createdAtElement = screen.getByText(defaultProps.createdAtLabel);
+        expect(createdAtElement).toHaveClass('truncate');
     });
 });

--- a/frontend/app/[locale]/(dashboard)/[UserID]/_components/board-card/Footer.tsx
+++ b/frontend/app/[locale]/(dashboard)/[UserID]/_components/board-card/Footer.tsx
@@ -6,11 +6,7 @@ interface FooterProps {
     disabled: boolean;
 }
 
-export const Footer = ({
-    title,
-    createdAtLabel,
-    disabled,
-}: FooterProps) => {
+export const Footer = ({ title, createdAtLabel, disabled }: FooterProps) => {
     return (
         <div className="relative p-3">
             <p className="text-[13px] truncate max-w-[calc(100%-20px)]">

--- a/frontend/app/[locale]/(dashboard)/[UserID]/_components/board-card/Footer.tsx
+++ b/frontend/app/[locale]/(dashboard)/[UserID]/_components/board-card/Footer.tsx
@@ -2,14 +2,12 @@ import { cn } from '@/lib/utils';
 
 interface FooterProps {
     title: string;
-    authorLabel: string;
     createdAtLabel: string;
     disabled: boolean;
 }
 
 export const Footer = ({
     title,
-    authorLabel,
     createdAtLabel,
     disabled,
 }: FooterProps) => {
@@ -19,7 +17,7 @@ export const Footer = ({
                 {title}
             </p>
             <p className="opacity-0 group-hover:opacity-100 transition-opacity text-[11px] text-muted-foreground truncate">
-                {authorLabel}, {createdAtLabel}
+                {createdAtLabel}
             </p>
             <button
                 disabled={disabled}

--- a/frontend/app/[locale]/(dashboard)/[UserID]/_components/board-card/Index.spec.tsx
+++ b/frontend/app/[locale]/(dashboard)/[UserID]/_components/board-card/Index.spec.tsx
@@ -84,6 +84,8 @@ describe('BoardCard Component', () => {
 
         const skeleton = screen.getByTestId('board-card-skeleton');
         expect(skeleton).toBeInTheDocument();
-        expect(skeleton).toHaveClass('aspect-[100/127] rounded-lg overflow-hidden');
+        expect(skeleton).toHaveClass(
+            'aspect-[100/127] rounded-lg overflow-hidden',
+        );
     });
 });

--- a/frontend/app/[locale]/(dashboard)/[UserID]/_components/board-card/Index.spec.tsx
+++ b/frontend/app/[locale]/(dashboard)/[UserID]/_components/board-card/Index.spec.tsx
@@ -1,9 +1,8 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { BoardCard } from '@/app/[locale]/(dashboard)/[UserID]/_components/board-card/Index';
 import { useRouter } from 'next/navigation';
 import { act } from 'react';
-import { useTranslations } from 'next-intl';
 import { useClerk } from '@clerk/nextjs';
 
 jest.mock('@/actions/CanvasSaver', () => ({
@@ -19,8 +18,6 @@ jest.mock('next/navigation', () => ({
 
 jest.mock('next-intl', () => ({
     useTranslations: jest.fn(() => (key: string) => {
-        if (key === 'you') return 'You';
-        if (key === 'teammate') return 'Teammate';
         return key;
     }),
     useLocale: jest.fn(() => 'en'),
@@ -41,13 +38,6 @@ describe('BoardCard Component', () => {
         orgId: 'org123',
     };
 
-    const mockUseTranslations = useTranslations as jest.Mock;
-    mockUseTranslations.mockImplementation(() => (key: string) => {
-        if (key === 'you') return 'You';
-        if (key === 'teammate') return 'Teammate';
-        return key;
-    });
-
     const mockUseClerk = useClerk as jest.Mock;
     mockUseClerk.mockReturnValue({ user: { firstName: 'Test User' } });
 
@@ -65,26 +55,6 @@ describe('BoardCard Component', () => {
         expect(screen.getByText(/ago/i)).toBeInTheDocument();
         // Check image
         expect(screen.getByAltText('')).toBeInTheDocument();
-    });
-
-    test('displays "You" when authorId matches UserID', async () => {
-        render(<BoardCard {...defaultProps} authorId="123" />);
-
-        await waitFor(() => {
-            expect(
-                screen.getByText((content) => content.includes('You')),
-            ).toBeInTheDocument();
-        });
-    });
-
-    test("displays the author's first name when authorId does not match UserID", async () => {
-        render(<BoardCard {...defaultProps} authorId="456" />);
-
-        await waitFor(() => {
-            expect(
-                screen.getByText((content) => content.includes('Test User')),
-            ).toBeInTheDocument();
-        });
     });
 
     test('navigates to board on click', async () => {
@@ -109,15 +79,11 @@ describe('BoardCard Component', () => {
         expect(card).toHaveClass('cursor-pointer');
     });
 
-    test('displays "Teammate" when authorId does not match UserID and user is null', async () => {
-        mockUseClerk.mockReturnValue({ user: null });
+    test('renders "Skeleton" correctly', () => {
+        render(<BoardCard.Skeleton />);
 
-        render(<BoardCard {...defaultProps} authorId="456" />);
-
-        await waitFor(() => {
-            expect(
-                screen.getByText((content) => content.includes('Teammate')),
-            ).toBeInTheDocument();
-        });
+        const skeleton = screen.getByTestId('board-card-skeleton');
+        expect(skeleton).toBeInTheDocument();
+        expect(skeleton).toHaveClass('aspect-[100/127] rounded-lg overflow-hidden');
     });
 });

--- a/frontend/app/[locale]/(dashboard)/[UserID]/_components/board-card/Index.tsx
+++ b/frontend/app/[locale]/(dashboard)/[UserID]/_components/board-card/Index.tsx
@@ -31,11 +31,11 @@ interface BoardCardProps {
 }
 
 export const BoardCard = ({
-                              id,
-                              title,
-                              createdAt,
-                              imageUrl,
-                          }: BoardCardProps) => {
+    id,
+    title,
+    createdAt,
+    imageUrl,
+}: BoardCardProps) => {
     const router = useRouter();
     const locale = useLocale() as LocaleKey;
     const [loading, setLoading] = useState(false);

--- a/frontend/app/[locale]/(dashboard)/[UserID]/_components/board-card/Index.tsx
+++ b/frontend/app/[locale]/(dashboard)/[UserID]/_components/board-card/Index.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { formatDistanceToNow } from 'date-fns';
+import { toZonedTime } from 'date-fns-tz';
 import { Skeleton } from '@/components/ui/Skeleton';
 import { Overlay } from './Overlay';
 import { Footer } from './Footer';
-import { useEffect, useState } from 'react';
-import { useParams, useRouter } from 'next/navigation';
-import { useLocale, useTranslations } from 'next-intl';
-import { useClerk } from '@clerk/nextjs';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useLocale } from 'next-intl';
 import Image from 'next/image';
 import { Actions } from '@/components/Action';
 import { MoreHorizontal } from 'lucide-react';
@@ -17,51 +17,34 @@ import { enUS, ru } from 'date-fns/locale';
 const dateFnsLocaleMap = {
     en: enUS,
     ru: ru,
-};
+} as const;
+
+type LocaleKey = keyof typeof dateFnsLocaleMap;
 
 interface BoardCardProps {
     id: string;
     title: string;
     authorId: string;
-    createdAt: Date;
+    createdAt: string;
     imageUrl: string;
     orgId: string;
 }
 
 export const BoardCard = ({
-    id,
-    title,
-    authorId,
-    createdAt,
-    imageUrl,
-}: BoardCardProps) => {
-    const t = useTranslations('utils');
+                              id,
+                              title,
+                              createdAt,
+                              imageUrl,
+                          }: BoardCardProps) => {
     const router = useRouter();
-    const locale = useLocale();
-    const params = useParams();
-    const { user } = useClerk();
-    const [authorLabel, setAuthorLabel] = useState(
-        params.UserID === authorId ? t('you') : t('teammate'),
-    );
+    const locale = useLocale() as LocaleKey;
     const [loading, setLoading] = useState(false);
 
-    useEffect(() => {
-        const getFirstName = async (userID: string) => {
-            if (userID === authorId) {
-                setAuthorLabel(t('you'));
-            } else if (user) {
-                setAuthorLabel(user.firstName || t('teammate'));
-            } else {
-                setAuthorLabel(t('teammate'));
-            }
-        };
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const zonedDate = toZonedTime(new Date(createdAt), timezone);
 
-        getFirstName(params.UserID as string);
-    }, [params.UserID, authorId, t, user]);
-
-    const createdAtLabel = formatDistanceToNow(new Date(createdAt), {
+    const createdAtLabel = formatDistanceToNow(zonedDate, {
         addSuffix: true,
-        // @ts-expect-error: Indexing works
         locale: dateFnsLocaleMap[locale],
     });
 
@@ -80,7 +63,7 @@ export const BoardCard = ({
         <div
             className="group aspect-[100/127] border rounded-lg flex cursor-pointer
             flex-col justify-between overflow-hidden relative"
-            data-testid={`board-card-${id}`} // Уникальный data-testid
+            data-testid={`board-card-${id}`}
             onClick={onClick}
         >
             <div className="relative flex-1">
@@ -97,7 +80,6 @@ export const BoardCard = ({
             </div>
             <Footer
                 title={title}
-                authorLabel={authorLabel}
                 createdAtLabel={createdAtLabel}
                 disabled={loading}
             />

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,6 +31,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "date-fns-tz": "^3.2.0",
         "lucide-react": "^0.470.0",
         "next": "^15.1.4",
         "next-intl": "^3.25.3",
@@ -6445,6 +6446,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/debug": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "date-fns-tz": "^3.2.0",
     "lucide-react": "^0.470.0",
     "next": "^15.1.4",
     "next-intl": "^3.25.3",


### PR DESCRIPTION
## Описание изменений
- Добавлена сортировка досок по полю createdAt в порядке убывания в методе getByOrgId.
- В методе createBoard поле createdAt теперь сохраняется как текущая дата в формате UTC.
- BoardList: Значение createdAt преобразуется в ISO-строку перед передачей в компонент.
- Footer: Убрано отображение authorLabel, упрощены стили.
- BoardCard: Добавлена обработка временных зон с помощью date-fns-tz.
- Обновлены тесты для учета изменений в структуре данных и отображении даты.

## Чек-лист
- [x] Написаны тесты
- [x] Изменения не ломают текущий функционал